### PR TITLE
Adicionado no calculo da : qty_delivered  - qty_invoiced ,

### DIFF
--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -4,26 +4,24 @@
 
 from odoo import api, fields, models
 
-from ...l10n_br_fiscal.constants.fiscal import TAX_FRAMEWORK
-
 
 class SaleOrderLine(models.Model):
-    _name = 'sale.order.line'
-    _inherit = [_name, 'l10n_br_fiscal.document.line.mixin']
+    _name = "sale.order.line"
+    _inherit = [_name, "l10n_br_fiscal.document.line.mixin"]
 
     country_id = fields.Many2one(related="company_id.country_id", store=True)
 
     @api.model
     def _default_fiscal_operation(self):
-        return self.env.user.company_id.sale_fiscal_operation_id
+        return self.env.company.sale_fiscal_operation_id
 
     @api.model
     def _fiscal_operation_domain(self):
-        domain = [('state', '=', 'approved')]
+        domain = [("state", "=", "approved")]
         return domain
 
     fiscal_operation_id = fields.Many2one(
-        comodel_name='l10n_br_fiscal.operation',
+        comodel_name="l10n_br_fiscal.operation",
         default=_default_fiscal_operation,
         domain=lambda self: self._fiscal_operation_domain(),
     )
@@ -38,11 +36,11 @@ class SaleOrderLine(models.Model):
 
     # Adapt Mixin's fields
     fiscal_tax_ids = fields.Many2many(
-        comodel_name='l10n_br_fiscal.tax',
-        relation='fiscal_sale_line_tax_rel',
-        column1='document_id',
-        column2='fiscal_tax_id',
-        string='Fiscal Taxes',
+        comodel_name="l10n_br_fiscal.tax",
+        relation="fiscal_sale_line_tax_rel",
+        column1="document_id",
+        column2="fiscal_tax_id",
+        string="Fiscal Taxes",
     )
 
     partner_order = fields.Char(string="Ordem de Compra (xPed)", size=15)
@@ -60,37 +58,36 @@ class SaleOrderLine(models.Model):
         compute="_compute_qty_delivered",
         compute_sudo=True,
         store=True,
-        digits='Product Unit of Measure',
+        digits="Product Unit of Measure",
     )
 
     uom_id = fields.Many2one(
-        related='product_uom',
-        depends=['product_uom'],
+        related="product_uom",
+        depends=["product_uom"],
     )
 
     tax_framework = fields.Selection(
-        selection=TAX_FRAMEWORK,
-        related='order_id.company_id.tax_framework',
-        string='Tax Framework',
+        related="order_id.company_id.tax_framework",
+        string="Tax Framework",
     )
 
     partner_id = fields.Many2one(
-        comodel_name='res.partner',
-        related='order_id.partner_id',
-        string='Partner',
+        comodel_name="res.partner",
+        related="order_id.partner_id",
+        string="Partner",
     )
 
     # Add Fields in model sale.order.line
     price_gross = fields.Monetary(
-        compute='_compute_amount', string='Gross Amount', compute_sudo=True
+        compute="_compute_amount", string="Gross Amount", compute_sudo=True
     )
 
     comment_ids = fields.Many2many(
-        comodel_name='l10n_br_fiscal.comment',
-        relation='sale_order_line_comment_rel',
-        column1='sale_line_id',
-        column2='comment_id',
-        string='Comments',
+        comodel_name="l10n_br_fiscal.comment",
+        relation="sale_order_line_comment_rel",
+        column1="sale_line_id",
+        column2="comment_id",
+        string="Comments",
     )
 
     discount_fixed = fields.Boolean(string="Fixed Discount?")
@@ -113,9 +110,9 @@ class SaleOrderLine(models.Model):
         company = self.env.company
         domain = []
         if company.cnae_main_id and company.cnae_secondary_ids:
-            cnae_main_id = company.cnae_main_id.id,
+            cnae_main_id = (company.cnae_main_id.id,)
             cnae_secondary_ids = company.cnae_secondary_ids.ids
-            domain = ['|', ('id', 'in', cnae_secondary_ids), ('id', '=', cnae_main_id)]
+            domain = ["|", ("id", "in", cnae_secondary_ids), ("id", "=", cnae_main_id)]
         return domain
 
     cnae_id = fields.Many2one(
@@ -127,9 +124,9 @@ class SaleOrderLine(models.Model):
     def _get_protected_fields(self):
         protected_fields = super()._get_protected_fields()
         return protected_fields + [
-            'fiscal_tax_ids', 
-            'fiscal_operation_id',
-            'fiscal_operation_line_id',
+            "fiscal_tax_ids",
+            "fiscal_operation_id",
+            "fiscal_operation_line_id",
         ]
 
     @api.depends(
@@ -145,7 +142,7 @@ class SaleOrderLine(models.Model):
         "tax_id",
     )
     def _compute_amount(self):
-        """Compute the amounts of the PO line."""
+        """Compute the amounts of the SO line."""
         super()._compute_amount()
         for line in self:
             # Update taxes fields
@@ -167,6 +164,7 @@ class SaleOrderLine(models.Model):
         result = self._prepare_br_fiscal_dict()
         if self.product_id and self.product_id.invoice_policy == "delivery":
             self._compute_qty_delivered()
+            result["fiscal_quantity"] = self.fiscal_qty_delivered
             result["fiscal_quantity"] = self.qty_to_invoice
 
         # Quando fatura item com o uot_factor preenchido sem isto o total de impostos na fatura
@@ -179,7 +177,7 @@ class SaleOrderLine(models.Model):
         result.update(super()._prepare_invoice_line(**optional_values))
         return result
 
-    @api.onchange('product_uom', 'product_uom_qty')
+    @api.onchange("product_uom", "product_uom_qty")
     def _onchange_product_uom(self):
         """To call the method in the mixin to update
         the price and fiscal quantity."""
@@ -198,14 +196,14 @@ class SaleOrderLine(models.Model):
             line.fiscal_qty_delivered = 0.0
             if line.product_id.invoice_policy == "delivery":
                 if line.uom_id == line.uot_id:
-                    line.fiscal_qty_delivered = line.qty_delivered
+                    line.fiscal_qty_delivered = line.qty_delivered - line.qty_invoiced
 
             if line.uom_id != line.uot_id:
                 line.fiscal_qty_delivered = (
-                    line.qty_delivered * line.product_id.uot_factor
+                    (line.qty_delivered - line.qty_invoiced) * line.product_id.uot_factor
                 )
 
-    @api.onchange('discount')
+    @api.onchange("discount")
     def _onchange_discount_percent(self):
         """Update discount value"""
         if not self.env.user.has_group("l10n_br_sale.group_discount_per_value"):
@@ -213,10 +211,10 @@ class SaleOrderLine(models.Model):
                 self.discount / 100
             )
 
-    @api.onchange('discount_value')
+    @api.onchange("discount_value")
     def _onchange_discount_value(self):
         """Update discount percent"""
-        if self.env.user.has_group('l10n_br_sale.group_discount_per_value'):
+        if self.env.user.has_group("l10n_br_sale.group_discount_per_value"):
             self.discount = (self.discount_value * 100) / (
                 self.product_uom_qty * self.price_unit or 1
             )


### PR DESCRIPTION
Quando  criava a última fatura de entregas parciais dava o erro :+1:
O montante expresso na moeda secundária deve ser positivo quando a conta é debitada e negativo quando a conta é creditada. Se a moeda for a mesma da empresa, este valor deve ser estritamente igual ao saldo.