### PR TITLE
Rótulo do produto (#831)

### DIFF
--- a/account_move_line_name/models/account_move.py
+++ b/account_move_line_name/models/account_move.py
@@ -23,11 +23,3 @@ class AccountMove(models.Model):
                     installments += 1
         return result
 
-    def button_draft(self):
-        result = super().button_draft()
-        # Apaga o campo rotulo da linha
-        for line in self.line_ids:
-            line.write({
-                'name': False
-            })
-        return result


### PR DESCRIPTION
remover a função que apaga o nome/rótulo do produto toda vez que a fatura volta para provisório